### PR TITLE
Add About page with header navigation

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,0 +1,10 @@
+export default function About() {
+  return (
+    <div className="app">
+      <div className="card">
+        <h1>Over deze app</h1>
+        <p>Dit is een eenvoudige demo-app gemaakt met React en Vite.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,31 @@
-import { useState } from 'react';
+import { useState, useEffect, ComponentType } from 'react';
+import Home from './Home';
+import About from './About';
+
+const routes: Record<string, ComponentType> = {
+  '#/': Home,
+  '#/about': About,
+};
 
 export default function App() {
-  const [count, setCount] = useState(0);
+  const [route, setRoute] = useState(window.location.hash || '#/');
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(window.location.hash || '#/');
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  const Page = routes[route] || Home;
+
   return (
-    <div className="app">
-      <div className="card">
-        <h1>Hallo wereld 👋</h1>
-        <small>Codex → Codespaces → GitHub</small>
-        <p style={{ marginTop: 12 }}>Kliks: {count}</p>
-        <button onClick={() => setCount((c) => c + 1)}>+1</button>
-      </div>
-    </div>
+    <>
+      <header>
+        <nav>
+          <a href="#/">Home</a> | <a href="#/about">About</a>
+        </nav>
+      </header>
+      <Page />
+    </>
   );
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [count, setCount] = useState(0);
+  return (
+    <div className="app">
+      <div className="card">
+        <h1>Hallo wereld 👋</h1>
+        <small>Codex → Codespaces → GitHub</small>
+        <p style={{ marginTop: 12 }}>Kliks: {count}</p>
+        <button onClick={() => setCount((c) => c + 1)}>+1</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add basic hash-based router and navigation header
- create About page and refactor home page component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af5c868d788322bcc2a8bf232e2413